### PR TITLE
Don't force /usr/bin/tidy, use the PATH, Luke

### DIFF
--- a/lib/html_validation/html_validation_result.rb
+++ b/lib/html_validation/html_validation_result.rb
@@ -58,11 +58,9 @@ class HTMLValidationResult
   end
 
   private
-  # We specifically prefer /usr/bin/tidy by default on *nix as there is another "tidy" program
-  # that could end up earlier on the path.  tidy was installed at this location for me by default.
+
   def tidy_command
-    is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-    bin = (is_windows or !File.exists?("/usr/bin/tidy")) ? 'tidy' : '/usr/bin/tidy'
+    bin = 'tidy'
     cmd = "#{bin} #{@tidy_flags.join(' ')}"
     cmd
   end


### PR DESCRIPTION
First of all, this is amazing. I was looking to implement valid HTML5 checking in my test suite and you solved that for me, so bravo.

However, I was dismayed to find out that the HTML5 version of tidy that I'd installed via homebrew was being ignored in favor of the ancient version installed by MacOS in /usr/bin because hmtl_validation wasn't respecting my path. I have my path set up this way for a reason, as I imagine most good devs do :) Please respect the path. That is all.
