### PR TITLE
Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ rvm:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y tidy
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head
 gemfile: Gemfile
 script: bundle exec rspec
 


### PR DESCRIPTION
Adds automated build & test on Travis-CI.

Example: https://travis-ci.org/moneyadviceservice/html_validation/builds/36238253

You'll need to enable Travis integration either before/after this gets merged to switch builds on in your fork.
