### PR TITLE
Allow to set the data_path variable when used in a Rails app

### DIFF
--- a/lib/html_validation/page_validations.rb
+++ b/lib/html_validation/page_validations.rb
@@ -123,8 +123,8 @@ module PageValidations
 
     def default_result_file_path
       posix      = RbConfig::CONFIG['host_os'] =~ /(darwin|linux)/
-      rootpath   = Rails.root if defined?(Rails)
-      rootpath ||= ::PageValidations.data_path if ::PageValidations.data_path
+      rootpath   = ::PageValidations.data_path if ::PageValidations.data_path
+      rootpath ||= Rails.root if defined?(Rails)
       rootpath ||= posix ? '/tmp/' : "c:\\tmp\\"
       File.join(rootpath, '.validation')
     end


### PR DESCRIPTION
When used in a Rails app, the `data_folder` was always defaulting to the Rails app's path.

This PR fixes that, allowing to set the `data_path` in the spec helper, like this: 

``` ruby
PageValidations.data_path = '/tmp/html_validation/'
```
