### PR TITLE
use File.exist? instead of File.exists? - ruby3 bugfix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    html_validation (1.1.5)
+    html_validation (1.1.6)
 
 GEM
   remote: http://rubygems.org/
@@ -34,4 +34,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.12.5
+   2.4.18

--- a/lib/html_validation/html_validation_result.rb
+++ b/lib/html_validation/html_validation_result.rb
@@ -44,7 +44,7 @@ class HTMLValidationResult
   # file system path, or url, so long it is uniquely associated with the passed in html.
   def valid?
     @exceptions = validate
-    File.delete(data_path("accepted")) if File.exists?(data_path("accepted")) if @exceptions == ''
+    File.delete(data_path("accepted")) if File.exist?(data_path("accepted")) if @exceptions == ''
     valid = (filter(@exceptions) == '' or accepted?(@exceptions))
     save_html_and_exceptions
     valid
@@ -58,7 +58,7 @@ class HTMLValidationResult
   end
 
   def reject!
-    if File.exists?(data_path("accepted"))
+    if File.exist?(data_path("accepted"))
       File.delete data_path("accepted")
     end
   end
@@ -90,7 +90,7 @@ class HTMLValidationResult
   # have we previously accepted this exact string for this path?
   def accepted?(exception_str)
     exception_str = filter(exception_str)
-    File.exists?(data_path('accepted')) ? filter(File.open(data_path('accepted'), "r").read) == exception_str : false
+    File.exist?(data_path('accepted')) ? filter(File.open(data_path('accepted'), "r").read) == exception_str : false
   end
 
   # Line numbers of exceptions are likely to change with any minor edit, so our validation

--- a/lib/html_validation/version.rb
+++ b/lib/html_validation/version.rb
@@ -1,3 +1,3 @@
 module PageValidations
-  HTML_VALIDATOR_VERSION = "1.1.5"
+  HTML_VALIDATOR_VERSION = "1.1.6"
 end

--- a/spec/html_validation_spec.rb
+++ b/spec/html_validation_spec.rb
@@ -4,7 +4,7 @@ describe "HTMLValidation" do
   include HTMLValidationHelpers
 
   before(:each) do
-    FileUtils.mkdir tmp_path if !File.exists?('/tmp/validation')
+    FileUtils.mkdir tmp_path if !File.exist?('/tmp/validation')
     @h = HTMLValidation.new('/tmp/validation')
   end
 


### PR DESCRIPTION
Starting from Ruby 3.2.0, the exists? (pluralized) alias was removed.

After this version, you need to use the singular-form `exist?`

Examples:

rvm use 3.1.3

```ruby
3.1.3 :001 > File.exist?("xyz")
=> false

3.1.3 :002 > File.exists?("xyz")
=> false

rvm use 3.2.0

3.2.0 :001 > File.exist?("xyz")
=> false

3.2.0 :002 > File.exists?("xyz")
(irb):2:in `<main>': undefined method `exists?' for File:Class (NoMethodError)
```